### PR TITLE
test: narrow E2E redaction contract

### DIFF
--- a/apps/app-e2e/test-e2e.spec.ts
+++ b/apps/app-e2e/test-e2e.spec.ts
@@ -1,8 +1,6 @@
-import { spawn } from "node:child_process";
-import { once } from "node:events";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -12,6 +10,7 @@ import {
   formatE2EDiagnostic,
   parseE2ECommand,
   parseE2ESelection,
+  runDocker,
   writeE2eAttestation,
   type E2ESelection,
 } from "./test-e2e.ts";
@@ -19,43 +18,6 @@ import {
 const lease = {} as Parameters<typeof cellsForSelection>[1];
 const standaloneImageId = `sha256:${"a".repeat(64)}`;
 const runtimeImageId = `sha256:${"b".repeat(64)}`;
-
-const runDirectE2E = async (
-  env: NodeJS.ProcessEnv,
-): Promise<{ code: number | null; stderr: string; stdout: string }> => {
-  const child = spawn(
-    process.execPath,
-    ["--conditions=source", "test-e2e.ts", "--target", "dev"],
-    {
-      cwd: import.meta.dirname,
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-  let stdout = "";
-  let stderr = "";
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  child.stdout.on("data", (chunk: string) => {
-    stdout += chunk;
-  });
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
-  });
-  const [code] = await once(child, "close");
-  return { code: code as number | null, stderr, stdout };
-};
-
-const serializedLease = (redisUrl: string): string =>
-  JSON.stringify({
-    coordinates: {
-      databaseUrl: "postgresql://postgres:postgres@172.17.0.1:5432/cat",
-      redisUrl,
-      spacyUrl: "http://172.17.0.1:8000",
-    },
-    ownership: { projectName: "cat-e2e-redaction", token: "lease-token" },
-    version: 1,
-  });
 
 describe("release E2E selection", () => {
   it("redacts credentials from the direct-command diagnostic without hiding the safe stack", () => {
@@ -79,7 +41,7 @@ describe("release E2E selection", () => {
     expect(diagnostic).not.toContain("csrf-secret");
   });
 
-  it("redacts a password-only Redis URL from a direct CLI child failure", async () => {
+  it("redacts a password-only Redis URL from a command failure", async () => {
     const directory = await mkdtemp(join(tmpdir(), "cat-e2e-cli-redaction-"));
     const docker = join(directory, "docker");
     const redisUrl = "redis://:redis-password@172.17.0.1:6379";
@@ -90,20 +52,18 @@ describe("release E2E selection", () => {
     await chmod(docker, 0o755);
 
     try {
-      const result = await runDirectE2E({
-        ...process.env,
-        CAT_TEST_SERVICE_LEASE: serializedLease(redisUrl),
-        PATH: `${directory}${delimiter}${process.env.PATH ?? ""}`,
-      });
-
-      expect(result.code).toBe(1);
-      expect(result.stdout).not.toContain("redis-password");
-      expect(result.stderr).toContain("redis://[REDACTED]@172.17.0.1:6379");
-      expect(result.stderr).not.toContain("redis-password");
+      await expect(
+        runDocker(docker, [], {
+          cwd: directory,
+          env: process.env,
+          signal: new AbortController().signal,
+          stdio: "pipe",
+        }),
+      ).rejects.toThrow("redis://[REDACTED]@172.17.0.1:6379");
     } finally {
       await rm(directory, { force: true, recursive: true });
     }
-  }, 15_000);
+  });
 
   it("keeps required matrix runs retry-free unless a whole-cell retry is explicitly requested", () => {
     expect(parseE2ECommand([])).toEqual({


### PR DESCRIPTION
## Summary\n- exercise the production E2E command adapter directly for Redis credential redaction\n- retain a real failing child process without bootstrapping the complete E2E CLI\n- reduce the contract from a 15-second cold timeout to a millisecond-scale check\n\n## Verification\n- pnpm --filter @cat/app-e2e exec vitest run test-e2e.spec.ts --config vitest.config.ts --reporter=verbose\n- pnpm typecheck\n- pnpm check