### PR TITLE
test: budget release E2E for slow runners

### DIFF
--- a/apps/app-e2e/execution-cell.spec.ts
+++ b/apps/app-e2e/execution-cell.spec.ts
@@ -19,6 +19,7 @@ import {
   isServerErrorDiagnostic,
   parseCellDatabaseName,
   playwrightChildEnvironment,
+  playwrightTimeoutMs,
   persistOneShotPreparerAttestation,
   processIdentityMatches,
   runAbortableCommand,
@@ -38,6 +39,11 @@ const input = {
 } satisfies ExecutionCellInput;
 
 const discardCellOutput = (_message: string): void => undefined;
+
+it("keeps the Playwright cell deadline below its verification node budget", () => {
+  expect(playwrightTimeoutMs).toBe(10 * 60_000);
+  expect(playwrightTimeoutMs).toBeLessThan(40 * 60_000);
+});
 
 const rejectedDeferred = <Value>(): {
   promise: Promise<Value>;

--- a/apps/app-e2e/execution-cell.ts
+++ b/apps/app-e2e/execution-cell.ts
@@ -72,7 +72,7 @@ const cleanupSettlementTimeoutMs = executionCellCleanupSettlementTimeoutMs;
 const processTerminationGraceMs = 5_000;
 const forcedProcessExitTimeoutMs = 5_000;
 const logDrainTimeoutMs = 5_000;
-const playwrightTimeoutMs = 480_000;
+export const playwrightTimeoutMs = 10 * 60_000;
 
 export type ExecutionTarget = "dev" | "standalone" | "runtime";
 export type ExecutionBrowser = "chromium" | "firefox";


### PR DESCRIPTION
## Summary\n- raise the Playwright cell deadline from 8 to 10 minutes after a valid standalone Firefox run reached 8m19s\n- export and contract-test the deadline while keeping it well below the 40-minute verification node budget\n- preserve retry-free execution and bounded process-group cleanup\n\n## Verification\n- execution-cell.spec.ts: 74/74\n- pnpm typecheck\n- pnpm check: 178/178