### PR TITLE
Improve dependency and CI maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,54 +8,77 @@ updates:
     versioning-strategy: increase
     open-pull-requests-limit: 20
     groups:
-      workspace-toolchain:
+      aws-sdk:
+        applies-to: version-updates
         patterns:
-          - turbo
-          - typescript
-          - "@typescript/*"
-          - oxlint
-          - oxfmt
-          - pnpm
-      frontend:
+          - "@aws-sdk/*"
+        update-types:
+          - patch
+          - minor
+      orpc:
+        applies-to: version-updates
         patterns:
-          - vue
-          - "@vue/*"
-          - "@vueuse/*"
-      backend:
+          - "@orpc/*"
+        update-types:
+          - patch
+          - minor
+      playwright:
+        applies-to: version-updates
         patterns:
-          - hono
-          - "@hono/*"
-          - "drizzle-*"
-      testing:
+          - playwright
+          - "@playwright/*"
+        update-types:
+          - patch
+          - minor
+      vitest:
+        applies-to: version-updates
         patterns:
           - vitest
           - "@vitest/*"
-          - playwright
-          - "@playwright/*"
+        update-types:
+          - patch
+          - minor
+      vue-core:
+        applies-to: version-updates
+        patterns:
+          - vue
+          - "@vue/compiler-*"
+        update-types:
+          - patch
+          - minor
+      vueuse:
+        applies-to: version-updates
+        patterns:
+          - "@vueuse/*"
+        update-types:
+          - patch
+          - minor
+      drizzle-core:
+        applies-to: version-updates
+        patterns:
+          - drizzle-kit
+          - drizzle-orm
+        update-types:
+          - patch
+          - minor
     ignore:
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
 
-  # One multi-directory group keeps both official Node image references together.
-  # The CI config contract requires the same exact patch in package.json engines.
   - package-ecosystem: docker
-    directories:
-      - /.devcontainer
-      - /apps/app
+    directory: /.devcontainer
     schedule:
       interval: weekly
-    groups:
-      node-runtime:
-        group-by: dependency-name
-        patterns:
-          - node
+    ignore:
+      - dependency-name: node
+
+  - package-ecosystem: uv
+    directory: /apps/spacy-server
+    schedule:
+      interval: weekly
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    groups:
-      github-actions:
-        patterns:
-          - "*"

--- a/apps/app-e2e/dev-probe-workspace.spec.ts
+++ b/apps/app-e2e/dev-probe-workspace.spec.ts
@@ -1,4 +1,5 @@
 import { access, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -9,14 +10,12 @@ import {
   writeDevHmrProbe,
 } from "./dev-probe-workspace.ts";
 
-const root = resolve(import.meta.dirname, "../..");
-
 describe("development probe workspace", () => {
-  it("keeps cell-scoped optimizer and HMR sources under the ignored workspace root", async () => {
-    const workspace = await createDevProbeWorkspace(root, "vitest-probe-cell");
+  it("keeps cell-scoped optimizer and HMR sources under the operating-system temporary directory", async () => {
+    const workspace = await createDevProbeWorkspace("vitest-probe-cell");
     try {
       expect(workspace.directory).toBe(
-        resolve(root, ".tmp/e2e/vitest-probe-cell"),
+        resolve(tmpdir(), "cat-e2e-probes/vitest-probe-cell"),
       );
       await writeDevHmrProbe(workspace, "application", "application-updated");
       await writeDevHmrProbe(workspace, "private-jit", "private-updated");
@@ -36,7 +35,7 @@ describe("development probe workspace", () => {
   });
 
   it("cleans failed probe content before the next cell creates its own sources", async () => {
-    const failed = await createDevProbeWorkspace(root, "vitest-failed-cell");
+    const failed = await createDevProbeWorkspace("vitest-failed-cell");
     try {
       await writeDevHmrProbe(failed, "application", "failed-update");
       throw new Error("simulated probe failure");
@@ -46,7 +45,7 @@ describe("development probe workspace", () => {
       await removeDevProbeWorkspace(failed);
     }
 
-    const next = await createDevProbeWorkspace(root, "vitest-next-cell");
+    const next = await createDevProbeWorkspace("vitest-next-cell");
     try {
       await expect(
         readFile(next.applicationSourcePath, "utf8"),

--- a/apps/app-e2e/dev-probe-workspace.ts
+++ b/apps/app-e2e/dev-probe-workspace.ts
@@ -1,4 +1,5 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 export type DevHmrProbeKind = "application" | "private-jit";
@@ -14,11 +15,8 @@ export type DevProbeWorkspace = {
 const moduleSource = (testId: string, value: string): string =>
   `<script setup lang="ts">\nconst value = ${JSON.stringify(value)};\n</script>\n\n<template>\n  <span data-testid="${testId}" :data-value="value" />\n</template>\n`;
 
-const assertWorkspaceDirectory = (
-  repositoryRoot: string,
-  directory: string,
-): void => {
-  const allowedRoot = resolve(repositoryRoot, ".tmp/e2e");
+const assertWorkspaceDirectory = (directory: string): void => {
+  const allowedRoot = resolve(tmpdir(), "cat-e2e-probes");
   const pathFromAllowedRoot = relative(allowedRoot, directory);
   if (
     pathFromAllowedRoot === "" ||
@@ -28,17 +26,16 @@ const assertWorkspaceDirectory = (
     pathFromAllowedRoot.startsWith("..\\")
   ) {
     throw new Error(
-      "Development probe workspace must be a cell below .tmp/e2e",
+      "Development probe workspace must be a cell below the system temporary probe root",
     );
   }
 };
 
 export const createDevProbeWorkspace = async (
-  repositoryRoot: string,
   cellId: string,
 ): Promise<DevProbeWorkspace> => {
-  const directory = resolve(repositoryRoot, ".tmp/e2e", cellId);
-  assertWorkspaceDirectory(repositoryRoot, directory);
+  const directory = resolve(tmpdir(), "cat-e2e-probes", cellId);
+  assertWorkspaceDirectory(directory);
   const applicationSourcePath = join(directory, "application-probe.vue");
   const privateJitDirectory = join(directory, "private-jit");
   const privateJitSourcePath = join(privateJitDirectory, "src/probe.vue");

--- a/apps/app-e2e/execution-cell.spec.ts
+++ b/apps/app-e2e/execution-cell.spec.ts
@@ -133,6 +133,10 @@ const readyReport = (profile: "lite" | "production") => ({
 });
 
 describe("ExecutionCell scheduler", () => {
+  it("uses the operating-system temporary directory for local diagnostics", () => {
+    expect(e2eArtifactRootFrom({})).toBe(join(tmpdir(), "cat-e2e"));
+  });
+
   it("places execution-cell diagnostics beneath the configured artifact root", () => {
     expect(
       e2eArtifactRootFrom({
@@ -1415,7 +1419,7 @@ describe("ExecutionCell scheduler", () => {
       "e2e cell target=dev browser=chromium image=development status=started",
     );
     expect(output[1]).toMatch(
-      /^e2e cell target=dev browser=chromium result=passed duration=\d+ms cleanup=passed$/,
+      /^e2e cell target=dev browser=chromium result=passed duration=\d+ms phases=prepare:\d+ms,bootstrap:\d+ms,external-service:\d+ms,hydrate:\d+ms,start:\d+ms,attest:\d+ms,playwright:\d+ms,stop:\d+ms cleanup=passed$/,
     );
     expect(existsSync(artifactDirectory)).toBe(false);
   });
@@ -1469,6 +1473,7 @@ describe("ExecutionCell scheduler", () => {
     await writeFile(join(playwrightOutput, ".auth", "admin.json"), "secret");
     await writeFile(join(playwrightOutput, "trace.zip"), "trace");
     const errors: string[] = [];
+    const replayLogs = vi.fn();
     const target: TargetAdapter = {
       applyExternalServicePlan: async () => undefined,
       attest: async () => undefined,
@@ -1481,7 +1486,8 @@ describe("ExecutionCell scheduler", () => {
           label: "test application",
           ownedPids: new Set(),
           processIdentities: new Map(),
-        }) satisfies StartedProcess,
+          replayLogs,
+        }) as StartedProcess,
       stop: async () => undefined,
     };
 
@@ -1511,7 +1517,10 @@ describe("ExecutionCell scheduler", () => {
       ),
     ]);
     expect(errors[0]).toContain("phase=playwright");
+    expect(errors[0]).toContain("last-phase=playwright");
+    expect(errors[0]).toMatch(/phases=.*playwright:\d+ms/);
     expect(errors[0]).toContain("browser validation failed");
+    expect(replayLogs).toHaveBeenCalledOnce();
     await rm(artifactDirectory, { force: true, recursive: true });
   });
 
@@ -2135,6 +2144,112 @@ describe("ExecutionCell scheduler", () => {
       expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
       expect(child.listenerCount("close")).toBe(0);
     } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("replays redacted captured command output when the command fails", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cat-e2e-replay-"));
+    const output = join(directory, "command.log");
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    try {
+      await expect(
+        runAbortableCommand(
+          process.execPath,
+          [
+            "-e",
+            "process.stdout.write('application startup failure\\n'); process.stderr.write('password=diagnostic-secret\\n'); process.exitCode=2",
+          ],
+          process.env,
+          "captured failure",
+          { outputPath: output },
+        ),
+      ).rejects.toThrow("captured failure exited with 2");
+
+      expect(readFileSync(output, "utf8")).toContain(
+        "password=diagnostic-secret",
+      );
+      expect(stdout).toHaveBeenCalledWith("application startup failure\n");
+      expect(stderr).toHaveBeenCalledWith("password=[REDACTED]\n");
+      expect(stderr).not.toHaveBeenCalledWith(
+        expect.stringContaining("diagnostic-secret"),
+      );
+    } finally {
+      stdout.mockRestore();
+      stderr.mockRestore();
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps captured command output quiet when the command succeeds", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cat-e2e-quiet-"));
+    const output = join(directory, "command.log");
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    try {
+      await runAbortableCommand(
+        process.execPath,
+        [
+          "-e",
+          "process.stdout.write('successful output\\n'); process.stderr.write('successful diagnostic\\n')",
+        ],
+        process.env,
+        "captured success",
+        { outputPath: output },
+      );
+
+      expect(readFileSync(output, "utf8")).toContain("successful output\n");
+      expect(readFileSync(output, "utf8")).toContain("successful diagnostic\n");
+      expect(stdout).not.toHaveBeenCalledWith("successful output\n");
+      expect(stderr).not.toHaveBeenCalledWith("successful diagnostic\n");
+    } finally {
+      stdout.mockRestore();
+      stderr.mockRestore();
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("bounds replayed failure output while retaining the complete local log", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cat-e2e-bounded-"));
+    const output = join(directory, "command.log");
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      await expect(
+        runAbortableCommand(
+          process.execPath,
+          [
+            "-e",
+            "process.stdout.write('x'.repeat(300000)); process.exitCode=2",
+          ],
+          process.env,
+          "large captured failure",
+          { outputPath: output },
+        ),
+      ).rejects.toThrow("large captured failure exited with 2");
+
+      expect(readFileSync(output, "utf8")).toHaveLength(300_000);
+      const replay = stdout.mock.calls.find(([value]) =>
+        String(value).startsWith("[diagnostic output truncated"),
+      );
+      expect(replay).toBeDefined();
+      expect(String(replay?.[0]).length).toBeGreaterThan(256_000);
+      expect(String(replay?.[0]).length).toBeLessThan(257_000);
+    } finally {
+      stdout.mockRestore();
       await rm(directory, { force: true, recursive: true });
     }
   });

--- a/apps/app-e2e/execution-cell.ts
+++ b/apps/app-e2e/execution-cell.ts
@@ -14,6 +14,7 @@ import {
   type Server,
   type Socket,
 } from "node:net";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { DrizzleDB, task, vectorizedString } from "@cat/db";
@@ -61,7 +62,7 @@ const root = resolve(import.meta.dirname, "../..");
 export const e2eArtifactRootFrom = (env: NodeJS.ProcessEnv): string =>
   resolve(
     env.CAT_E2E_ARTIFACT_ROOT === undefined || env.CAT_E2E_ARTIFACT_ROOT === ""
-      ? join(root, ".tmp", "e2e")
+      ? join(tmpdir(), "cat-e2e")
       : env.CAT_E2E_ARTIFACT_ROOT,
   );
 const startupTimeoutMs = 300_000;
@@ -72,6 +73,7 @@ const cleanupSettlementTimeoutMs = executionCellCleanupSettlementTimeoutMs;
 const processTerminationGraceMs = 5_000;
 const forcedProcessExitTimeoutMs = 5_000;
 const logDrainTimeoutMs = 5_000;
+const diagnosticReplayCharacterLimit = 256_000;
 export const playwrightTimeoutMs = 10 * 60_000;
 
 export type ExecutionTarget = "dev" | "standalone" | "runtime";
@@ -126,6 +128,7 @@ export type StartedProcess = {
   label: string;
   ownedPids: Set<number>;
   processIdentities: Map<number, ProcessIdentity>;
+  replayLogs?: () => void;
 };
 
 type ProcessIdentity = {
@@ -226,6 +229,13 @@ const cellIdentity = (input: ExecutionCellInput): string =>
 const cellDuration = (startedAt: number): string =>
   `${Math.round(performance.now() - startedAt)}ms`;
 
+const formatPhaseDurations = (
+  durations: ReadonlyMap<ExecutionCellPhase, number>,
+): string =>
+  [...durations]
+    .map(([phase, duration]) => `${phase}:${Math.round(duration)}ms`)
+    .join(",");
+
 const waitForAbortableDelay = async (
   milliseconds: number,
   signal: AbortSignal,
@@ -282,8 +292,10 @@ const attachServerDiagnostics = (
   child: ChildProcess,
   log: ReturnType<typeof createWriteStream>,
   diagnostics: Error[],
-): Pick<StartedProcess, "drainLogs" | "forceDrainLogs"> => {
+): Pick<StartedProcess, "drainLogs" | "forceDrainLogs" | "replayLogs"> => {
   const flushes: Array<() => void> = [];
+  let capturedOutput = "";
+  let capturedOutputTruncated = false;
   for (const stream of [child.stdout, child.stderr]) {
     let pending = "";
     const consume = (line: string): void => {
@@ -296,7 +308,13 @@ const attachServerDiagnostics = (
       }
     };
     stream?.on("data", (chunk: Buffer | string) => {
-      const lines = `${pending}${chunk.toString()}`.split("\n");
+      const value = chunk.toString();
+      capturedOutput += value;
+      if (capturedOutput.length > diagnosticReplayCharacterLimit) {
+        capturedOutputTruncated = true;
+        capturedOutput = capturedOutput.slice(-diagnosticReplayCharacterLimit);
+      }
+      const lines = `${pending}${value}`.split("\n");
       pending = lines.pop() ?? "";
       for (const line of lines) consume(line);
     });
@@ -321,9 +339,19 @@ const attachServerDiagnostics = (
     log.once("finish", resolveDrain);
     log.once("error", rejectDrain);
   });
+  let replayed = false;
   return {
     drainLogs: async () => await drained,
     forceDrainLogs: endLog,
+    replayLogs: () => {
+      if (replayed) return;
+      replayed = true;
+      replayCapturedDiagnostic(
+        capturedOutput,
+        process.stderr.write.bind(process.stderr),
+        capturedOutputTruncated,
+      );
+    },
   };
 };
 
@@ -451,6 +479,24 @@ const closeOutputStream = async (
   });
 };
 
+const replayCapturedDiagnostic = (
+  value: string,
+  write: (value: string) => boolean,
+  alreadyTruncated = false,
+): void => {
+  if (value === "") return;
+  const truncated =
+    alreadyTruncated || value.length > diagnosticReplayCharacterLimit;
+  const bounded =
+    value.length > diagnosticReplayCharacterLimit
+      ? value.slice(-diagnosticReplayCharacterLimit)
+      : value;
+  const diagnostic = redactDiagnosticText(
+    `${truncated ? `[diagnostic output truncated to last ${diagnosticReplayCharacterLimit} characters]\n` : ""}${bounded}`,
+  );
+  write(diagnostic.endsWith("\n") ? diagnostic : `${diagnostic}\n`);
+};
+
 export const runManagedCommand = async (
   command: string,
   args: string[],
@@ -542,7 +588,19 @@ export const runManagedCommand = async (
               [initialFailure, processGroupExitFailure],
               `Could not confirm ${label} stopped`,
             );
+      const replayOutput = (): void => {
+        if (options.outputPath === undefined || stdio !== "capture") return;
+        replayCapturedDiagnostic(
+          stdout,
+          process.stdout.write.bind(process.stdout),
+        );
+        replayCapturedDiagnostic(
+          stderr,
+          process.stderr.write.bind(process.stderr),
+        );
+      };
       if (finalFailure !== undefined) {
+        replayOutput();
         reject(finalFailure);
         return;
       }
@@ -550,6 +608,7 @@ export const runManagedCommand = async (
         resolveRun({ stderr, stdout });
         return;
       }
+      replayOutput();
       const diagnostic = stderr.trim();
       reject(
         new Error(
@@ -558,7 +617,7 @@ export const runManagedCommand = async (
               ? diagnostic === ""
                 ? ""
                 : `: ${diagnostic}`
-              : `; see ${options.outputPath}`
+              : ""
           }`,
         ),
       );
@@ -1976,11 +2035,28 @@ export class DevTargetAdapter implements TargetAdapter {
 
   public async bootstrap(runtime: CellRuntime): Promise<void> {
     const bootstrap = await this.start(runtime, "bootstrap");
+    let bootstrapFailure: unknown;
     try {
       await waitForApplicationBootstrap(runtime, bootstrap, this.signal);
-    } finally {
-      await this.stop(bootstrap);
+    } catch (error) {
+      bootstrapFailure = error;
     }
+    let stopFailure: unknown;
+    try {
+      await this.stop(bootstrap);
+    } catch (error) {
+      stopFailure = error;
+    }
+    if (bootstrapFailure !== undefined || stopFailure !== undefined)
+      bootstrap.replayLogs?.();
+    if (bootstrapFailure !== undefined && stopFailure !== undefined) {
+      throw new AggregateError(
+        [bootstrapFailure, stopFailure],
+        "Development bootstrap and shutdown failed",
+      );
+    }
+    if (bootstrapFailure !== undefined) throw bootstrapFailure;
+    if (stopFailure !== undefined) throw stopFailure;
   }
 
   public async start(
@@ -3303,31 +3379,63 @@ export class ExecutionCell {
     let primaryFailure: unknown;
     let primaryFailurePhase: ExecutionCellPhase = "prepare";
     const failurePhases = new Map<Error, ExecutionCellPhase>();
+    const phaseDurations = new Map<ExecutionCellPhase, number>();
+    const runPhase = async <Value>(
+      phase: ExecutionCellPhase,
+      operation: () => Promise<Value>,
+    ): Promise<Value> => {
+      primaryFailurePhase = phase;
+      const phaseStartedAt = performance.now();
+      try {
+        return await operation();
+      } finally {
+        phaseDurations.set(
+          phase,
+          (phaseDurations.get(phase) ?? 0) + performance.now() - phaseStartedAt,
+        );
+      }
+    };
     let runtime: CellRuntime | undefined;
+    let validationProcess: StartedProcess | undefined;
     try {
+      const { activeRuntime, target } = await runPhase("prepare", async () => {
+        this.throwIfAborted();
+        const preparedRuntime =
+          (await this.dependencies.createRuntime?.(this.register.bind(this))) ??
+          (await this.createRuntime());
+        runtime = preparedRuntime;
+        this.artifactDirectory ??= preparedRuntime.artifactDirectory;
+        this.throwIfAborted();
+        const preparedTarget =
+          this.dependencies.createTarget?.(this.input) ??
+          adapterFor(this.input, this.register.bind(this), this.signal);
+        await preparedTarget.prepare(preparedRuntime);
+        return { activeRuntime: preparedRuntime, target: preparedTarget };
+      });
       this.throwIfAborted();
-      runtime =
-        (await this.dependencies.createRuntime?.(this.register.bind(this))) ??
-        (await this.createRuntime());
-      this.artifactDirectory ??= runtime.artifactDirectory;
+      await runPhase(
+        "bootstrap",
+        async () => await target.bootstrap(activeRuntime),
+      );
       this.throwIfAborted();
-      const target =
-        this.dependencies.createTarget?.(this.input) ??
-        adapterFor(this.input, this.register.bind(this), this.signal);
-      primaryFailurePhase = "prepare";
-      await target.prepare(runtime);
+      await runPhase(
+        "external-service",
+        async () => await target.applyExternalServicePlan(activeRuntime),
+      );
       this.throwIfAborted();
-      primaryFailurePhase = "bootstrap";
-      await target.bootstrap(runtime);
+      await runPhase(
+        "hydrate",
+        async () =>
+          await (this.dependencies.hydrateFixtures ?? hydrateFixtures)(
+            activeRuntime,
+          ),
+      );
       this.throwIfAborted();
-      primaryFailurePhase = "external-service";
-      await target.applyExternalServicePlan(runtime);
-      this.throwIfAborted();
-      primaryFailurePhase = "hydrate";
-      await (this.dependencies.hydrateFixtures ?? hydrateFixtures)(runtime);
-      this.throwIfAborted();
-      primaryFailurePhase = "start";
-      const validation = await target.start(runtime, "validation");
+      const validation = await runPhase(
+        "start",
+        async () => await target.start(activeRuntime, "validation"),
+      );
+      validationProcess = validation;
       const unregisterValidation = this.register(
         "validation application process",
         async (signal) => await target.stop(validation, signal),
@@ -3335,16 +3443,20 @@ export class ExecutionCell {
       if (this.input.target !== "dev") {
         this.register(
           "cell loopback proxy",
-          await createLoopbackProxy(runtime),
+          await createLoopbackProxy(activeRuntime),
         );
       }
-      primaryFailurePhase = "attest";
-      await target.attest(runtime, validation);
+      await runPhase(
+        "attest",
+        async () => await target.attest(activeRuntime, validation),
+      );
       this.throwIfAborted();
       let playwrightFailure: unknown;
       try {
-        primaryFailurePhase = "playwright";
-        await this.runPlaywright(runtime.environment);
+        await runPhase(
+          "playwright",
+          async () => await this.runPlaywright(activeRuntime.environment),
+        );
       } catch (error) {
         playwrightFailure = error;
         failurePhases.set(toError(error), "playwright");
@@ -3352,8 +3464,7 @@ export class ExecutionCell {
 
       let stopFailure: unknown;
       try {
-        primaryFailurePhase = "stop";
-        await target.stop(validation);
+        await runPhase("stop", async () => await target.stop(validation));
         unregisterValidation();
       } catch (error) {
         stopFailure = error;
@@ -3425,7 +3536,7 @@ export class ExecutionCell {
       try {
         await this.removeArtifacts();
         write(
-          `e2e cell ${identity} result=passed duration=${cellDuration(startedAt)} cleanup=passed`,
+          `e2e cell ${identity} result=passed duration=${cellDuration(startedAt)} phases=${formatPhaseDurations(phaseDurations)} cleanup=passed`,
         );
         return;
       } catch (error) {
@@ -3434,16 +3545,21 @@ export class ExecutionCell {
         failurePhases.set(failure, "artifact-cleanup");
       }
     }
+    validationProcess?.replayLogs?.();
     const cleanup = cleanupFailures.length === 0 ? "passed" : "failed";
     const artifact = this.artifactDirectory ?? "<not-created>";
     write(
-      `e2e cell ${identity} result=failed duration=${cellDuration(startedAt)} cleanup=${cleanup}`,
+      `e2e cell ${identity} result=failed duration=${cellDuration(startedAt)} phases=${formatPhaseDurations(phaseDurations)} cleanup=${cleanup}`,
     );
     const cleanupFailureDetails = cleanupFailures
       .map((failure) => formatFailureTree(failure, failurePhases, "cleanup"))
       .join("; ");
+    const lastPhase =
+      primaryFailure === undefined
+        ? (failurePhases.get(cleanupFailures[0]!) ?? "cleanup")
+        : primaryFailurePhase;
     writeError(
-      `e2e cell ${identity} result=failed artifact=${artifact} cleanup=${cleanup} failure=${
+      `e2e cell ${identity} result=failed artifact=${artifact} cleanup=${cleanup} last-phase=${lastPhase} phases=${formatPhaseDurations(phaseDurations)} failure=${
         primaryFailure === undefined
           ? cleanupFailureDetails
           : formatFailureTree(
@@ -3483,7 +3599,7 @@ export class ExecutionCell {
       ),
     );
     this.artifactDirectory = artifactDirectory;
-    const probeWorkspace = await createDevProbeWorkspace(root, cellId);
+    const probeWorkspace = await createDevProbeWorkspace(cellId);
     this.register(
       "development probe workspace",
       async () => await removeDevProbeWorkspace(probeWorkspace),

--- a/apps/app-e2e/tests/project-shell-refresh.spec.ts
+++ b/apps/app-e2e/tests/project-shell-refresh.spec.ts
@@ -9,8 +9,7 @@ test.describe("Project shell SSR refresh", () => {
     const projectId = refs["project"];
 
     await gotoHydrated(page, `/project/${projectId}/pull-requests`);
-    await page.waitForLoadState("networkidle");
-    await reloadHydrated(page, { waitUntil: "networkidle" });
+    await reloadHydrated(page);
 
     await expect(page.getByRole("navigation")).toContainText("拉取请求");
     await expect(page.getByText("main").first()).toBeVisible();
@@ -23,8 +22,7 @@ test.describe("Project shell SSR refresh", () => {
     const projectId = refs["project"];
 
     await gotoHydrated(page, `/project/${projectId}/workflows`);
-    await page.waitForLoadState("networkidle");
-    await reloadHydrated(page, { waitUntil: "networkidle" });
+    await reloadHydrated(page);
 
     await expect(page.getByRole("navigation")).toContainText("工作流");
     await expect(page.getByText("main").first()).toBeVisible();

--- a/apps/app/src/vite-config.spec.ts
+++ b/apps/app/src/vite-config.spec.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -27,12 +27,9 @@ describe("server workspace externalization", () => {
     const packagesRoot = resolve(import.meta.dirname, "../../../packages");
     const privateJitPackages = readdirSync(packagesRoot).flatMap(
       (directory) => {
-        const manifest = parseJson(
-          readFileSync(
-            resolve(packagesRoot, directory, "package.json"),
-            "utf8",
-          ),
-        );
+        const manifestPath = resolve(packagesRoot, directory, "package.json");
+        if (!existsSync(manifestPath)) return [];
+        const manifest = parseJson(readFileSync(manifestPath, "utf8"));
         return isRecord(manifest) &&
           manifest.private === true &&
           hasTypeScriptSourceExport(manifest.exports) &&

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { tmpdir } from "node:os";
 import { isAbsolute, relative, resolve } from "node:path";
 
 import { injectApplicationWebSocket } from "@cat/app-api/app";
@@ -21,7 +22,7 @@ const resolvedProbeRoot =
   probeRoot === undefined ? undefined : resolve(workspaceRoot, probeRoot);
 
 if (resolvedProbeRoot !== undefined) {
-  const probeParent = resolve(workspaceRoot, ".tmp/e2e");
+  const probeParent = resolve(tmpdir(), "cat-e2e-probes");
   const probePath = relative(probeParent, resolvedProbeRoot);
   if (
     probePath === "" ||
@@ -30,7 +31,9 @@ if (resolvedProbeRoot !== undefined) {
     probePath.startsWith("../") ||
     probePath.startsWith("..\\")
   ) {
-    throw new Error("CAT_E2E_HMR_PROBE_DIRECTORY must be below .tmp/e2e");
+    throw new Error(
+      "CAT_E2E_HMR_PROBE_DIRECTORY must be below the system temporary probe root",
+    );
   }
 }
 
@@ -55,7 +58,7 @@ const hmrProbePaths = (): string[] => [
 const initializeDevelopmentServer = () => ({
   name: "cat:initialize-development-server",
   configureServer(server: ViteDevServer) {
-    // E2E places its private source package below .tmp, outside Vite's root.
+    // E2E places its private source package outside Vite's workspace root.
     // Aliasing resolves the import, while this registers the actual file events.
     server.watcher.add(hmrProbePaths());
     if (!(server.httpServer instanceof http.Server)) {
@@ -155,6 +158,9 @@ export default defineConfig({
   },
 
   server: {
+    ...(resolvedProbeRoot === undefined
+      ? {}
+      : { fs: { allow: [workspaceRoot, resolvedProbeRoot] } }),
     watch: {
       ignored: ["plugins/**"],
     },

--- a/packages/shared/src/utils/logger/core.spec.ts
+++ b/packages/shared/src/utils/logger/core.spec.ts
@@ -137,6 +137,12 @@ describe("Logger", () => {
     expect(redactDiagnosticText(diagnostic)).toBe(diagnostic);
   });
 
+  it("handles large ordinary diagnostics without URL-pattern backtracking", () => {
+    const diagnostic = "x".repeat(300_000);
+
+    expect(redactDiagnosticText(diagnostic)).toBe(diagnostic);
+  });
+
   it("recursively formats bounded error trees without exposing credentials", () => {
     const cleanup = new Error("cleanup password=cleanup-secret");
     const root = new AggregateError(

--- a/packages/shared/src/utils/logger/core.ts
+++ b/packages/shared/src/utils/logger/core.ts
@@ -15,7 +15,7 @@ const SENSITIVE_TEXT =
   /(["']?(?:authorization|cookie|password|secret|token|api[-_]?key|credential|session(?:[-_]?id)?|csrf(?:[-_]?token)?)["']?)(\s*[:=]\s*)(?:Bearer\s+[^\s,;}&]+|"[^"]*"|'[^']*'|[^\s,;}&]+)/gi;
 const BEARER_TOKEN = /\bBearer\s+[^\s,;}&]+/gi;
 const URL_USERINFO =
-  /([a-z][a-z\d+.-]*:\/\/)(?:[^\s/@:?#]*:[^\s/@?#]*|[^\s/@:?#]+)@/gi;
+  /(^|[^a-z\d+.-])([a-z][a-z\d+.-]*:\/\/)(?:[^\s/@:?#]*:[^\s/@?#]*|[^\s/@:?#]+)@/gi;
 
 type LoggerState = {
   readonly transports: readonly DiagnosticTransport[];
@@ -45,7 +45,7 @@ const isCustomEventConstructor = (
 /** Redacts credentials before diagnostic text crosses a process boundary. */
 export const redactDiagnosticText = (value: string): string =>
   value
-    .replace(URL_USERINFO, `$1${REDACTED}@`)
+    .replace(URL_USERINFO, `$1$2${REDACTED}@`)
     .replace(
       SENSITIVE_TEXT,
       (_match, key: string, separator: string) =>

--- a/scripts/ci-config-contract.spec.ts
+++ b/scripts/ci-config-contract.spec.ts
@@ -85,6 +85,18 @@ const actionStep = (name: string): WorkflowStep => {
   return step!;
 };
 
+const compatibilityCohort = (
+  patterns: string[],
+): {
+  "applies-to": "version-updates";
+  patterns: string[];
+  "update-types": ["patch", "minor"];
+} => ({
+  "applies-to": "version-updates",
+  patterns,
+  "update-types": ["patch", "minor"],
+});
+
 describe("CI configuration contract", () => {
   it("projects the typed plan into the distributed Complete Verification graph", () => {
     expect(workflow.on).toMatchObject({
@@ -540,7 +552,15 @@ describe("CI configuration contract", () => {
       updates?: Array<{
         directories?: string[];
         directory?: string;
-        groups?: Record<string, { "group-by"?: string; patterns?: string[] }>;
+        groups?: Record<
+          string,
+          {
+            "applies-to"?: string;
+            patterns?: string[];
+            "update-types"?: string[];
+          }
+        >;
+        ignore?: Array<{ "dependency-name"?: string }>;
         "package-ecosystem"?: string;
       }>;
       version?: number;
@@ -551,29 +571,45 @@ describe("CI configuration contract", () => {
     expect(dependabot.version).toBe(2);
     expect(
       dependabot.updates?.map((update) => update["package-ecosystem"]),
-    ).toEqual(["npm", "docker", "github-actions"]);
+    ).toEqual(["npm", "docker", "uv", "github-actions"]);
 
     const npm = dependabot.updates?.find(
       (update) => update["package-ecosystem"] === "npm",
     );
     expect(npm?.directory).toBe("/");
-    expect(npm?.groups).toHaveProperty("workspace-toolchain");
-    expect(npm?.groups).toHaveProperty("testing");
-
-    const nodeImages = dependabot.updates?.find(
-      (update) => update.directories !== undefined,
-    );
-    expect(nodeImages?.["package-ecosystem"]).toBe("docker");
-    expect(nodeImages?.directories).toEqual(["/.devcontainer", "/apps/app"]);
-    expect(nodeImages?.groups?.["node-runtime"]).toEqual({
-      "group-by": "dependency-name",
-      patterns: ["node"],
+    expect(npm?.groups).toEqual({
+      "aws-sdk": compatibilityCohort(["@aws-sdk/*"]),
+      "drizzle-core": compatibilityCohort(["drizzle-kit", "drizzle-orm"]),
+      orpc: compatibilityCohort(["@orpc/*"]),
+      playwright: compatibilityCohort(["playwright", "@playwright/*"]),
+      vitest: compatibilityCohort(["vitest", "@vitest/*"]),
+      "vue-core": compatibilityCohort(["vue", "@vue/compiler-*"]),
+      vueuse: compatibilityCohort(["@vueuse/*"]),
     });
+
+    const devcontainerImages = dependabot.updates?.find(
+      (update) => update["package-ecosystem"] === "docker",
+    );
+    expect(devcontainerImages?.directory).toBe("/.devcontainer");
+    expect(devcontainerImages?.ignore).toContainEqual({
+      "dependency-name": "node",
+    });
+
+    const uv = dependabot.updates?.find(
+      (update) => update["package-ecosystem"] === "uv",
+    );
+    expect(uv?.directory).toBe("/apps/spacy-server");
+
     expect(
       dependabot.updates?.filter(
         (update) => update["package-ecosystem"] === "github-actions",
       ),
     ).toHaveLength(1);
+    expect(
+      dependabot.updates?.find(
+        (update) => update["package-ecosystem"] === "github-actions",
+      )?.groups,
+    ).toBeUndefined();
   });
 
   it("provides Docker CLI, buildx, and Compose through the Dockerfile-first devcontainer", () => {


### PR DESCRIPTION
## What changed

- replace broad Dependabot groups with proven compatibility cohorts, isolate majors, keep Node image updates out of Dependabot, and add native uv updates
- make failed E2E commands and server processes replay bounded, redacted diagnostics while keeping successful output quiet
- report semantic lifecycle phase durations and remove `networkidle` synchronization from SSR refresh coverage
- place E2E diagnostics and HMR probe workspaces under `os.tmpdir()`, with Vite access limited to the active probe directory
- tolerate local context-only package directories without manifests
- remove a quadratic URL-redaction path exposed by large failure output

## Why

The long-running dependency update batch exposed weak failure attribution in both Dependabot grouping and E2E diagnostics. It also exposed repository-local temporary directories and a diagnostic redaction performance regression. These changes keep the full CI gate while making update failures independently attributable and actionable without increasing timeouts.

## Impact

Routine npm, Docker, GitHub Actions, and uv updates remain proposal-only and run through the complete verification graph. Node stays on the repository-owned Node 24 LTS patch contract. Failed browser cells provide immediate redacted terminal context plus retained native Playwright evidence.

## Validation

- `pnpm check` — 178/178 tasks passed
- `pnpm test:e2e -- --target dev --concurrency 1` — 35/35 passed
- standalone E2E — Chromium and Firefox 33/33 passed
- runtime E2E — Chromium and Firefox 33/33 passed
- focused redaction regression — 300k-character diagnostic reduced from about 41s to 29ms
